### PR TITLE
Agent v6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ If you are ready with this, go directly to Step 3: Installing the check.
 2. Install python libraries
   1. Use pip to install the Google API client for Python: `/opt/datadog-agent/embedded/bin/pip install --upgrade google-api-python-client`
 3. Install the check:
-  - Copy ga.yaml to /etc/dd-agent/conf.d/
-  - Copy ga.py to /etc/dd-agent/checks.d/
-  - Copy the api key json file to the server in a directory the agent can access *(ie: /etc/dd-agent/conf.d/)*
-4. Configure by adding the account information and the properties (views) you want to integrate in `/etc/dd-agent/conf.d/ga.yaml`. 
+  - Copy ga.yaml to /etc/datadog-agent/conf.d/
+  - Copy ga.py to /etc/datadog-agent/checks.d/
+  - Copy the api key json file to the server in a directory the agent can access *(ie: /etc/datadog-agent/conf.d/)*
+4. Configure by adding the account information and the properties (views) you want to integrate in `/etc/datadog-agent/conf.d/ga.yaml`. 
   - In the following example, the query divides the pageviews in 3 dimensions (country, city, device). For more information about available dimensions go to [this page](https://developers.google.com/analytics/devguides/reporting/realtime/dimsmets/).
   - Be carefull with the *min_collection_interval* paramter. Google Analytics generate a by-minute result in the Real Time response with no timestamp. The only way to correlate Analytics data with the other metrics is running every 60 seconds aprox.
 
@@ -57,7 +57,7 @@ If you are ready with this, go directly to Step 3: Installing the check.
   init_config:
     min_collection_interval: 55
     service_account_email: my-svc-account@my-project.12345.iam.gserviceaccount.com
-    key_file_location: /opt/datadog-agent/etc/conf.d/key.json
+    key_file_location: /etc/datadog-agent/conf.d/key.json
 
   instances:
 

--- a/ga.yaml
+++ b/ga.yaml
@@ -6,9 +6,8 @@
 # - Be sure Datadog Agent can read key file.
 #
 init_config:
-    min_collection_interval: 55
     service_account_email: example@my-project.iam.gserviceaccount.com
-    key_file_location: /opt/datadog-agent/etc/conf.d/key.json
+    key_file_location: /etc/datadog-agent/conf.d/key.json
     
 # - Create as many instances as google profiles will reported to Datadog
 # - Each metric will be tagged with: profile + tags + dimensions
@@ -17,7 +16,9 @@ init_config:
 #
 # Example
 #
+instances:
 #   - profile: ga:12345678
+#     min_collection_interval: 55
 #     tags:
 #      - env:production
 #     pageview_dimensions:


### PR DESCRIPTION
Notes:
- tested on Agent v5 and Agent v6
- collection_interval changed from init level to instance level [ref](https://docs.datadoghq.com/developers/write_agent_check/?tab=agentv6#collection-interval).
- self.gauge(..) does not accept timestamp in v6 [ref](https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#check-api). This impacts on the 1 minute-ago logic and the timestamps reported.
- removed unused service_account_email